### PR TITLE
I've added an example project for the local Sanity client.

### DIFF
--- a/examples/test-local-project/README.md
+++ b/examples/test-local-project/README.md
@@ -1,0 +1,51 @@
+# Test Local Sanity Project
+
+This project demonstrates a local replacement for the Sanity client API, allowing for local data operations with a similar interface. All data is stored in memory and, for assets, in a local `local_assets/` directory within this project.
+
+## Included Files
+
+The `src/` directory contains:
+- `localSanityTypes.ts`: TypeScript interfaces for the client and data structures.
+- `inMemoryStore.ts`: A simple in-memory database implementation.
+- `localSanityClient.ts`: The local Sanity client implementation.
+- `example.sanity.config.ts`: Example configuration for the local client.
+- `example.usage.ts`: A script demonstrating various operations using the local client.
+- `localApi.test.ts`: Unit tests for the store and client.
+
+## Prerequisites
+
+- Node.js (v16 or later recommended)
+- pnpm (or npm/yarn)
+
+## Setup
+
+1.  Navigate to this project's directory:
+    ```bash
+    cd examples/test-local-project
+    ```
+2.  Install dependencies:
+    ```bash
+    pnpm install
+    # OR npm install
+    # OR yarn install
+    ```
+
+## Running the Example Usage
+
+To see the local client in action, run the main example script:
+
+```bash
+pnpm start
+# OR npm start
+```
+This will execute `src/example.usage.ts`, which demonstrates creating, fetching, updating, deleting documents, listening to real-time updates, and uploading assets. Check the console output. A `local_assets/` directory will be created here if it doesn't exist.
+
+## Running Tests
+
+To run the unit tests for the local client and store:
+
+```bash
+pnpm test
+# OR npm test
+```
+This will execute `src/localApi.test.ts`.

--- a/examples/test-local-project/package.json
+++ b/examples/test-local-project/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-local-sanity-project",
+  "version": "1.0.0",
+  "description": "An example project demonstrating a local Sanity client implementation.",
+  "main": "src/example.usage.ts",
+  "scripts": {
+    "start": "ts-node src/example.usage.ts",
+    "test": "ts-node src/localApi.test.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.0",
+    "@types/node": "^20.0.0"
+  },
+  "license": "MIT"
+}

--- a/examples/test-local-project/src/example.sanity.config.ts
+++ b/examples/test-local-project/src/example.sanity.config.ts
@@ -1,0 +1,126 @@
+/**
+ * @remarks
+ * This file provides an example configuration for the LocalSanityClient,
+ * mimicking the structure of a typical sanity.config.ts file.
+ */
+
+import { LocalSanityClientImpl } from './localSanityClient';
+import { LocalSanityClientConfig, LocalSanityClient } from './localSanityTypes';
+
+/**
+ * Creates a factory function for producing configured LocalSanityClient instances.
+ * This allows for base configurations to be set and then overridden if needed
+ * when a client instance is requested.
+ *
+ * @param baseConfig - The base configuration for the local Sanity client.
+ * @returns A function that, when called, returns a new LocalSanityClient instance.
+ *          This returned function can optionally take an overrideConfig to merge
+ *          with the baseConfig.
+ */
+export function createLocalClientFactory(baseConfig: LocalSanityClientConfig) {
+  /**
+   * Returns a configured instance of the LocalSanityClient.
+   * @param overrideConfig - Optional configuration to override the base factory settings.
+   * @returns A new LocalSanityClient instance.
+   */
+  return function getConfiguredClient(overrideConfig?: Partial<LocalSanityClientConfig>): LocalSanityClient {
+    const finalConfig: LocalSanityClientConfig = { ...baseConfig, ...overrideConfig };
+    return new LocalSanityClientImpl(finalConfig);
+  };
+}
+
+/**
+ * Example "workspace" or project configuration for the LocalSanityClient.
+ * This structure is inspired by Sanity's `defineConfig`.
+ */
+export const localProjectConfig = {
+  /**
+   * A unique identifier for the local project.
+   */
+  projectId: 'local-project-example',
+
+  /**
+   * The primary dataset for this project configuration.
+   * Can be overridden by the client factory if needed.
+   */
+  dataset: 'production',
+
+  /**
+   * API version string, primarily for display or compatibility simulation.
+   * The local client does not strictly enforce API versions like the real Sanity client.
+   */
+  apiVersion: 'v2024-03-15',
+
+  /**
+   * A factory for creating instances of the LocalSanityClient.
+   * This instance is pre-configured with a default dataset and log level.
+   */
+  clientFactory: createLocalClientFactory({
+    dataset: 'production', // Default dataset for clients from this factory
+    logLevel: 'info',      // Default log level
+    // localDataPath: './data/production', // Example: if persistence was desired
+  }),
+
+  /**
+   * Placeholder for schema definitions, similar to Sanity's structure.
+   * Not actively used by the LocalSanityClient itself but good for structural parity.
+   */
+  schema: {
+    types: [], // Example: define schema types here
+  },
+
+  /**
+   * Placeholder for plugins, similar to Sanity's structure.
+   */
+  plugins: [
+    // Example: mockPlugin({ setting: true }),
+  ],
+
+  /**
+   * Title for the project, useful for UI if this config were used in a broader tool.
+   */
+  title: 'Local Sanity Project',
+};
+
+// --- Example Usage ---
+/*
+// Get a client instance using the default factory configuration
+const defaultClient = localProjectConfig.clientFactory();
+console.log('Default client config:', defaultClient.config);
+
+// Get a client instance overriding the dataset for staging
+const stagingClient = localProjectConfig.clientFactory({
+  dataset: 'staging',
+  // localDataPath: './data/staging', // Example for staging data
+  logLevel: 'debug',
+});
+console.log('Staging client config:', stagingClient.config);
+
+async function runClientExamples() {
+  try {
+    // Using default client
+    await defaultClient.create({ _id: 'doc1', _type: 'test', title: 'Document 1 (Prod)' });
+    const doc1Prod = await defaultClient.getDocument('doc1');
+    console.log('Fetched doc1 (Prod):', doc1Prod);
+
+    // Using staging client
+    await stagingClient.create({ _id: 'doc1', _type: 'test', title: 'Document 1 (Staging)' });
+    const doc1Staging = await stagingClient.getDocument('doc1'); // Will be from staging's in-memory store
+    console.log('Fetched doc1 (Staging):', doc1Staging);
+
+    const allProdDocs = await defaultClient.fetch('*');
+    console.log('All Prod Docs:', allProdDocs.length); // Should be 1 if stores are separate
+
+    const allStagingDocs = await stagingClient.fetch('*');
+    console.log('All Staging Docs:', allStagingDocs.length); // Should be 1
+
+  } catch (error) {
+    console.error('Error during client examples:', error);
+  }
+}
+
+// runClientExamples();
+*/
+
+// To make this file a module
+export default localProjectConfig;

--- a/examples/test-local-project/src/example.usage.ts
+++ b/examples/test-local-project/src/example.usage.ts
@@ -1,0 +1,231 @@
+/**
+ * @remarks
+ * This file demonstrates various operations of the LocalSanityClient.
+ * It serves as a usage guide and an integration test.
+ */
+
+import { localProjectConfig } from './example.sanity.config';
+import { SanityDocument, AssetMetadata } from './localSanityTypes';
+import * as fs from 'fs';
+import * as path from 'path';
+
+async function main() {
+  console.log('--- Local Sanity Client Usage Example ---');
+
+  // --- 0. Define and Cleanup local_assets directory from previous runs ---
+  // `__dirname` is examples/test-local-project/src, so '..' goes to examples/test-local-project/
+  const assetsDir = path.resolve(__dirname, '..', 'local_assets');
+  console.log(`Using assets directory: ${assetsDir}`);
+
+  if (fs.existsSync(assetsDir)) {
+    console.log('\n--- Cleaning up existing local_assets directory ---');
+    try {
+      fs.rmSync(assetsDir, { recursive: true, force: true });
+      console.log('local_assets directory cleaned successfully.');
+    } catch (e) {
+      console.error('Error cleaning up local_assets directory:', e);
+    }
+  }
+
+
+  // --- 1. Client Initialization ---
+  console.log('\n--- 1. Client Initialization ---');
+  const client = localProjectConfig.clientFactory({
+    // Using a specific dataset for this example run for clarity
+    dataset: 'example-usage',
+    logLevel: 'info', // Set to 'debug' for more verbose client output
+  });
+  console.log('Client initialized with config:', client.config);
+
+  let authorId: string;
+  let postId: string;
+
+  // --- 2. Creating Documents ---
+  console.log('\n--- 2. Creating Documents ---');
+  try {
+    const authorDoc: Partial<SanityDocument> = {
+      _type: 'author',
+      name: 'Jane Doe',
+      email: 'jane.doe@example.com',
+    };
+    // Forcing an ID for predictable testing, normally Sanity auto-generates _id
+    const createdAuthor = await client.create({ ...authorDoc, _id: 'author-jane-doe' } as SanityDocument);
+    authorId = createdAuthor._id;
+    console.log('Created Author:', createdAuthor);
+
+    const postDoc: Partial<SanityDocument> = {
+      _type: 'post',
+      title: 'My First Post',
+      author: { _type: 'reference', _ref: authorId },
+      body: 'This is the content of my first post.',
+    };
+    const createdPost = await client.create({ ...postDoc, _id: 'post-my-first-post' } as SanityDocument);
+    postId = createdPost._id;
+    console.log('Created Post:', createdPost);
+  } catch (error) {
+    console.error('Error creating documents:', error);
+  }
+
+  // --- 3. Fetching Documents ---
+  console.log('\n--- 3. Fetching Documents ---');
+  try {
+    const fetchedPost = await client.getDocument(postId);
+    console.log(`Fetched Post by ID ("${postId}"):`, fetchedPost);
+
+    const postsByType = await client.fetch('*[_type == "post"]');
+    console.log('Fetched Posts by Type ("post"):', postsByType);
+
+    const allDocs = await client.fetch('*');
+    console.log('Fetched All Documents:', allDocs);
+  } catch (error) {
+    console.error('Error fetching documents:', error);
+  }
+
+  // --- 4. Patching Documents ---
+  console.log('\n--- 4. Patching Documents ---');
+  try {
+    const patchResult = await client.patch(postId, { title: 'My Updated First Post', views: 100 }).commit();
+    console.log('Patch Commit Result:', patchResult);
+    // patchResult.results will contain an object like { id: postId, operation: 'patch', document: updatedDoc }
+
+    const updatedPost = await client.getDocument(postId);
+    console.log('Fetched Updated Post:', updatedPost);
+  } catch (error) {
+    console.error('Error patching document:', error);
+  }
+
+  // --- 5. Listening to Updates ---
+  console.log('\n--- 5. Listening to Updates ---');
+  const listener = client.listen('*[_type == "post" || _type == "author"]'); // Listen to post or author changes
+  let eventCount = 0;
+
+  const subscription = listener.subscribe((event) => {
+    console.log(`Real-time Event Received (Count: ${++eventCount}):`, event);
+    // Example: event might be { type: 'create' | 'update' | 'delete', documentId: '...', document?: SanityDocument }
+  });
+  console.log('Subscribed to real-time updates for posts and authors.');
+
+  try {
+    // Trigger some events
+    console.log('Performing operations to trigger listener...');
+    await client.patch(postId, { lastUpdatedBy: 'listener_test' }).commit();
+    const anotherPost = await client.create({ _id: 'post-listener-test', _type: 'post', title: 'Listener Test Post' } as SanityDocument);
+    await client.delete(anotherPost._id);
+
+    // Wait a moment for events to be processed if operations are very fast
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+  } catch (error) {
+    console.error('Error during operations for listener test:', error);
+  } finally {
+    subscription.unsubscribe();
+    console.log('Unsubscribed from real-time updates.');
+  }
+
+
+  // --- 6. Deleting Documents ---
+  console.log('\n--- 6. Deleting Documents ---');
+  try {
+    const deleteResult = await client.delete(authorId);
+    console.log('Delete Author Result:', deleteResult);
+
+    const deletedAuthor = await client.getDocument(authorId);
+    console.log(`Fetched Deleted Author ("${authorId}"):`, deletedAuthor); // Should be undefined
+  } catch (error) {
+    console.error('Error deleting document:', error);
+  }
+
+  // --- 7. Uploading Assets ---
+  console.log('\n--- 7. Uploading Assets ---');
+  // Dummy files will be created in examples/test-local-project/
+  const dummyTextFilePath = path.resolve(__dirname, '..', 'dummy.txt');
+  const dummyImageFilePath = path.resolve(__dirname, '..', 'dummy.png'); // Simulate with a text file
+  console.log(`Dummy text file path: ${dummyTextFilePath}`);
+  console.log(`Dummy image file path: ${dummyImageFilePath}`);
+
+  let fileAssetMeta: AssetMetadata | null = null;
+  let imageAssetMeta: AssetMetadata | null = null;
+
+  try {
+    // Create dummy files
+    fs.writeFileSync(dummyTextFilePath, 'Hello World from dummy.txt!');
+    fs.writeFileSync(dummyImageFilePath, 'This is not a real PNG, just dummy data for dummy.png');
+    console.log('Dummy files created for asset upload at project root.');
+
+    // File Upload
+    console.log('Uploading file asset...');
+    fileAssetMeta = await client.assets.upload(
+      'file',
+      { path: dummyTextFilePath, name: 'dummy.txt', type: 'text/plain' },
+      { filename: 'uploaded_dummy_file.txt' }
+    );
+    console.log('File Asset Metadata:', fileAssetMeta);
+
+    // Image Upload (Simulated)
+    console.log('Uploading image asset (simulated)...');
+    imageAssetMeta = await client.assets.upload(
+      'image',
+      { path: dummyImageFilePath, name: 'dummy.png', type: 'image/png' }, // type is 'image/png' even if content isn't
+      { filename: 'uploaded_image_file.png' }
+    );
+    console.log('Image Asset Metadata:', imageAssetMeta);
+
+    // Verify asset documents in store
+    if (fileAssetMeta) {
+      const fetchedFileAssetDoc = await client.getDocument(fileAssetMeta._id);
+      console.log('Fetched File Asset Document from store:', fetchedFileAssetDoc);
+    }
+    if (imageAssetMeta) {
+      const fetchedImageAssetDoc = await client.getDocument(imageAssetMeta._id);
+      console.log('Fetched Image Asset Document from store:', fetchedImageAssetDoc);
+    }
+
+    // Verify files in local_assets/
+    console.log('Verifying files in local_assets directory...');
+    if (fileAssetMeta && fs.existsSync(path.join(assetsDir, path.basename(fileAssetMeta.url)))) {
+      console.log(`File asset confirmed in local_assets: ${fileAssetMeta.url}`);
+    } else if (fileAssetMeta) {
+      console.error(`File asset NOT FOUND in local_assets: ${fileAssetMeta.url}`);
+    }
+
+    if (imageAssetMeta && fs.existsSync(path.join(assetsDir, path.basename(imageAssetMeta.url)))) {
+      console.log(`Image asset confirmed in local_assets: ${imageAssetMeta.url}`);
+    } else if (imageAssetMeta){
+      console.error(`Image asset NOT FOUND in local_assets: ${imageAssetMeta.url}`);
+    }
+
+  } catch (error) {
+    console.error('Error uploading assets:', error);
+  } finally {
+    // Clean up dummy files
+    if (fs.existsSync(dummyTextFilePath)) fs.unlinkSync(dummyTextFilePath);
+    if (fs.existsSync(dummyImageFilePath)) fs.unlinkSync(dummyImageFilePath);
+    console.log('Dummy files for asset upload cleaned up.');
+  }
+
+  // --- 8. Error Handling Examples ---
+  console.log('\n--- 8. Error Handling Examples ---');
+  try {
+    console.log('Attempting to fetch a non-existent document...');
+    const nonExistentDoc = await client.getDocument('does-not-exist-123');
+    console.log('Non-existent document result (should be undefined):', nonExistentDoc); // Should be undefined
+  } catch (error) {
+    // This specific client's getDocument might return undefined instead of throwing.
+    // The store's methods (like create for duplicate ID) are more likely to throw.
+    console.error('Error fetching non-existent document (as expected if it threw):', error);
+  }
+
+  try {
+    console.log('Attempting to create a document with a duplicate ID...');
+    await client.create({ _id: postId, _type: 'post', title: 'Duplicate Post Fail' } as SanityDocument);
+  } catch (error) {
+    console.error('Error creating document with duplicate ID (as expected):', (error as Error).message);
+  }
+
+  console.log('\n--- Example Script Finished ---');
+}
+
+main().catch(error => {
+  console.error('Unhandled error in main execution:', error);
+  process.exit(1); // Exit with error code if main crashes
+});

--- a/examples/test-local-project/src/inMemoryStore.ts
+++ b/examples/test-local-project/src/inMemoryStore.ts
@@ -1,0 +1,106 @@
+import { SanityDocument } from './localSanityTypes';
+
+/**
+ * A simple in-memory store for Sanity documents.
+ */
+export class InMemoryStore {
+  /**
+   * Stores documents, keyed by their _id.
+   */
+  private documents: Map<string, SanityDocument>;
+
+  /**
+   * Initializes a new instance of the InMemoryStore.
+   */
+  constructor() {
+    this.documents = new Map<string, SanityDocument>();
+  }
+
+  /**
+   * Retrieves a document by its ID.
+   * @param id - The ID of the document to retrieve.
+   * @returns A promise that resolves with the document, or undefined if not found.
+   */
+  async get(id: string): Promise<SanityDocument | undefined> {
+    return this.documents.get(id);
+  }
+
+  /**
+   * Creates a new document.
+   * @param doc - The document to create.
+   * @returns A promise that resolves with the created document.
+   * @throws Error if a document with the same _id already exists.
+   */
+  async create(doc: SanityDocument): Promise<SanityDocument> {
+    if (this.documents.has(doc._id)) {
+      throw new Error(`Document with _id "${doc._id}" already exists.`);
+    }
+    // Ensure _createdAt and _updatedAt are set
+    const now = new Date().toISOString();
+    const newDoc = {
+      ...doc,
+      _createdAt: doc._createdAt || now,
+      _updatedAt: doc._updatedAt || now,
+    };
+    this.documents.set(newDoc._id, newDoc);
+    return newDoc;
+  }
+
+  /**
+   * Updates an existing document.
+   * @param id - The ID of the document to update.
+   * @param fields - An object containing the fields to merge into the existing document.
+   * @returns A promise that resolves with the updated document.
+   * @throws Error if the document with the given id is not found.
+   */
+  async update(id: string, fields: Partial<SanityDocument>): Promise<SanityDocument> {
+    const existingDoc = this.documents.get(id);
+    if (!existingDoc) {
+      throw new Error(`Document with _id "${id}" not found.`);
+    }
+    const updatedDoc = {
+      ...existingDoc,
+      ...fields,
+      _updatedAt: new Date().toISOString(),
+    };
+    this.documents.set(id, updatedDoc);
+    return updatedDoc;
+  }
+
+  /**
+   * Deletes a document by its ID.
+   * @param id - The ID of the document to delete.
+   * @returns A promise that resolves with the deleted document, or undefined if it didn't exist.
+   */
+  async delete(id: string): Promise<SanityDocument | undefined> {
+    const docToDelete = this.documents.get(id);
+    if (docToDelete) {
+      this.documents.delete(id);
+    }
+    return docToDelete;
+  }
+
+  /**
+   * Queries the documents based on a filter function.
+   * @param filterFn - A function that takes a document and returns true if it matches the query.
+   * @returns A promise that resolves with an array of documents that match the filter.
+   */
+  async query(filterFn: (doc: SanityDocument) => boolean): Promise<SanityDocument[]> {
+    const results: SanityDocument[] = [];
+    for (const doc of this.documents.values()) {
+      if (filterFn(doc)) {
+        results.push(doc);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Clears all documents from the store.
+   * Useful for testing purposes.
+   * @returns A promise that resolves when the store is cleared.
+   */
+  async clear(): Promise<void> {
+    this.documents.clear();
+  }
+}

--- a/examples/test-local-project/src/localApi.test.ts
+++ b/examples/test-local-project/src/localApi.test.ts
@@ -1,0 +1,375 @@
+/**
+ * @remarks
+ * Unit tests for InMemoryStore and LocalSanityClientImpl.
+ */
+
+import { InMemoryStore } from './inMemoryStore';
+import { LocalSanityClientImpl } from './localSanityClient';
+import { SanityDocument, AssetMetadata, LocalSanityClientConfig } from './localSanityTypes';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// --- Assertion Utility ---
+let testsPassed = 0;
+let testsFailed = 0;
+const testResults: { name: string, passed: boolean, error?: string }[] = [];
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(`Assertion Failed: ${message}`);
+  }
+}
+
+// --- Helper: Delay function ---
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// --- Test Functions for InMemoryStore ---
+
+async function testStoreDocumentLifecycle() {
+  const store = new InMemoryStore();
+  const docId = 'doc1';
+  const initialDoc: SanityDocument = {
+    _id: docId,
+    _type: 'test',
+    _createdAt: new Date().toISOString(),
+    _updatedAt: new Date().toISOString(),
+    title: 'Initial Title',
+  };
+
+  // Create
+  const createdDoc = await store.create(initialDoc);
+  assert(createdDoc._id === docId, 'Store Create: ID should match.');
+  assert(createdDoc.title === 'Initial Title', 'Store Create: Title should match.');
+
+  // Get
+  const fetchedDoc = await store.get(docId);
+  assert(fetchedDoc !== undefined, 'Store Get: Document should exist.');
+  assert(fetchedDoc!._id === docId, 'Store Get: ID should match.');
+  assert(fetchedDoc!.title === 'Initial Title', 'Store Get: Title should match.');
+
+  // Update
+  const oldUpdatedAt = fetchedDoc!._updatedAt;
+  await delay(10); // Ensure _updatedAt changes
+  const updatedDoc = await store.update(docId, { title: 'Updated Title', newField: true });
+  assert(updatedDoc.title === 'Updated Title', 'Store Update: Title should be updated.');
+  assert((updatedDoc as any).newField === true, 'Store Update: New field should exist.');
+  assert(updatedDoc._updatedAt !== oldUpdatedAt, 'Store Update: _updatedAt should change.');
+
+  // Delete
+  const deletedDoc = await store.delete(docId);
+  assert(deletedDoc !== undefined, 'Store Delete: Should return deleted document.');
+  assert(deletedDoc!._id === docId, 'Store Delete: Deleted doc ID should match.');
+  const afterDelete = await store.get(docId);
+  assert(afterDelete === undefined, 'Store Delete: Document should not exist after deletion.');
+}
+
+async function testStoreDuplicateId() {
+  const store = new InMemoryStore();
+  const docId = 'dup1';
+  await store.create({ _id: docId, _type: 'test', _createdAt: '', _updatedAt: '' });
+
+  try {
+    await store.create({ _id: docId, _type: 'test2', _createdAt: '', _updatedAt: '' });
+    assert(false, 'Store Duplicate ID: Should have thrown an error for duplicate ID.');
+  } catch (e) {
+    assert((e as Error).message.includes(`Document with _id "${docId}" already exists.`), 'Store Duplicate ID: Error message mismatch.');
+  }
+}
+
+async function testStoreUpdateNonExistent() {
+  const store = new InMemoryStore();
+  try {
+    await store.update('nonexistent', { title: 'No Such Doc' });
+    assert(false, 'Store Update Non-Existent: Should have thrown an error.');
+  } catch (e) {
+    assert((e as Error).message.includes('Document with _id "nonexistent" not found.'), 'Store Update Non-Existent: Error message mismatch.');
+  }
+}
+
+async function testStoreQuery() {
+  const store = new InMemoryStore();
+  const docs: SanityDocument[] = [
+    { _id: 'q1', _type: 'typeA', name: 'Alice', value: 10, _createdAt: '', _updatedAt: '' },
+    { _id: 'q2', _type: 'typeB', name: 'Bob', value: 20, _createdAt: '', _updatedAt: '' },
+    { _id: 'q3', _type: 'typeA', name: 'Charlie', value: 10, _createdAt: '', _updatedAt: '' },
+  ];
+  for (const doc of docs) {
+    await store.create(doc);
+  }
+
+  // Query by type
+  let results = await store.query(doc => doc._type === 'typeA');
+  assert(results.length === 2, 'Store Query: Type A should return 2 docs.');
+  assert(results.some(d => d._id === 'q1') && results.some(d => d._id === 'q3'), 'Store Query: Type A results incorrect.');
+
+  // Query by specific field value
+  results = await store.query(doc => (doc as any).value === 10);
+  assert(results.length === 2, 'Store Query: Value 10 should return 2 docs.');
+
+  // Query by name
+  results = await store.query(doc => (doc as any).name === 'Bob');
+  assert(results.length === 1, 'Store Query: Name Bob should return 1 doc.');
+  assert(results[0]._id === 'q2', 'Store Query: Name Bob result incorrect.');
+
+  // Query with no matches
+  results = await store.query(doc => doc._type === 'typeC');
+  assert(results.length === 0, 'Store Query: Type C should return 0 docs.');
+}
+
+async function testStoreClear() {
+  const store = new InMemoryStore();
+  await store.create({ _id: 'c1', _type: 'test', _createdAt: '', _updatedAt: '' });
+  await store.create({ _id: 'c2', _type: 'test', _createdAt: '', _updatedAt: '' });
+
+  await store.clear();
+  const allDocs = await store.query(() => true);
+  assert(allDocs.length === 0, 'Store Clear: Store should be empty after clear.');
+}
+
+
+// --- Test Functions for LocalSanityClientImpl ---
+
+const defaultClientConfig: LocalSanityClientConfig = { dataset: 'test-client', logLevel: 'error' };
+const assetsTestDir = path.join(process.cwd(), 'local_assets_test_client');
+
+// Helper to clean up asset directory
+function cleanupAssetsTestDir() {
+  if (fs.existsSync(assetsTestDir)) {
+    fs.rmSync(assetsTestDir, { recursive: true, force: true });
+  }
+}
+
+// Helper to get client's internal store for direct manipulation/assertion
+async function getClientStore(client: LocalSanityClientImpl): Promise<InMemoryStore> {
+  // This is a hack for testing; real applications wouldn't access the store directly.
+  // Assuming 'store' is a private property, this won't work directly without type assertion or making it protected/public for tests.
+  // For this example, we'll assume it's accessible or we'd use client methods to populate.
+  // If 'store' is private, we'd need to populate via client.create() for setup.
+  return (client as any).store as InMemoryStore;
+}
+
+
+async function testClientFetchQueries() {
+  const client = new LocalSanityClientImpl(defaultClientConfig);
+  const store = await getClientStore(client);
+  await store.clear(); // Ensure clean state
+
+  const docs: SanityDocument[] = [
+    { _id: 'fetchDoc1', _type: 'testType', name: 'Fetch Test 1', _createdAt: '', _updatedAt: '' },
+    { _id: 'fetchDoc2', _type: 'testType2', name: 'Fetch Test 2', _createdAt: '', _updatedAt: '' },
+    { _id: 'fetchDoc3', _type: 'testType', name: 'Fetch Test 3', _createdAt: '', _updatedAt: '' },
+  ];
+  for (const doc of docs) {
+    await client.create(doc); // Use client.create to ensure events are handled if store is truly private
+  }
+
+  let result = await client.fetch('fetchDoc1');
+  assert(result !== undefined && result._id === 'fetchDoc1', 'Client Fetch: Get by ID failed.');
+
+  result = await client.fetch('*[_type == "testType"]');
+  assert(Array.isArray(result) && result.length === 2, 'Client Fetch: Query by type failed.');
+  assert(result.every((d: SanityDocument) => d._type === 'testType'), 'Client Fetch: Query by type results incorrect type.');
+
+  result = await client.fetch('*[_type == $typeParam]', { typeParam: 'testType2' });
+  assert(Array.isArray(result) && result.length === 1 && result[0]._type === 'testType2', 'Client Fetch: Query by type with param failed.');
+
+  result = await client.fetch('*');
+  assert(Array.isArray(result) && result.length === 3, 'Client Fetch: Query all (*) failed.');
+  
+  result = await client.fetch('*[_type == ^"invalid"]'); // Unsupported query
+  assert(Array.isArray(result) && result.length === 0, 'Client Fetch: Unsupported query should return empty array.');
+}
+
+async function testClientTransactions() {
+  const client = new LocalSanityClientImpl(defaultClientConfig);
+  const store = await getClientStore(client);
+  await store.clear();
+
+  const docToCreateId = 'txDocCreate';
+  const docToPatchId = 'txDocPatch';
+  const docToDeleteId = 'txDocDelete';
+
+  await client.create({ _id: docToPatchId, _type: 'txTest', title: 'Initial', _createdAt: '', _updatedAt: '' });
+  await client.create({ _id: docToDeleteId, _type: 'txTest', title: 'To Delete', _createdAt: '', _updatedAt: '' });
+
+  const receivedEvents: any[] = [];
+  const listener = client.listen('*');
+  const subscription = listener.subscribe(event => receivedEvents.push(event));
+
+  const tx = client.transaction();
+  tx.create({ _id: docToCreateId, _type: 'txTest', title: 'Created in TX', _createdAt: '', _updatedAt: '' } as SanityDocument);
+  tx.patch(docToPatchId, { title: 'Patched in TX', version: 2 });
+  tx.delete(docToDeleteId);
+
+  const commitResult = await tx.commit();
+  assert(commitResult.results.length === 3, 'Client Transaction: Commit should return 3 results.');
+
+  // Verify store state
+  const createdInTx = await store.get(docToCreateId);
+  assert(createdInTx !== undefined && createdInTx.title === 'Created in TX', 'Client Transaction: Create operation failed.');
+
+  const patchedInTx = await store.get(docToPatchId);
+  assert(patchedInTx !== undefined && patchedInTx.title === 'Patched in TX' && (patchedInTx as any).version === 2, 'Client Transaction: Patch operation failed.');
+  assert(patchedInTx!._updatedAt !== docs.find(d=>d._id === docToPatchId)?._updatedAt, 'Client Transaction: Patch _updatedAt should change.');
+
+
+  const deletedInTx = await store.get(docToDeleteId);
+  assert(deletedInTx === undefined, 'Client Transaction: Delete operation failed.');
+
+  // Verify event emission
+  await delay(50); // Allow events to propagate
+  assert(receivedEvents.length >= 3, `Client Transaction: Expected at least 3 events, got ${receivedEvents.length}.`);
+  assert(receivedEvents.some(e => e.type === 'create' && e.documentId === docToCreateId), 'Client Transaction: Create event missing.');
+  assert(receivedEvents.some(e => e.type === 'update' && e.documentId === docToPatchId), 'Client Transaction: Patch (update) event missing.');
+  assert(receivedEvents.some(e => e.type === 'delete' && e.documentId === docToDeleteId), 'Client Transaction: Delete event missing.');
+
+  subscription.unsubscribe();
+}
+
+async function testClientListen() {
+  const client = new LocalSanityClientImpl(defaultClientConfig);
+  const store = await getClientStore(client);
+  await store.clear();
+
+  const listenDocId = 'lt1';
+  const listenDocType = 'listenTest';
+  const receivedEvents: any[] = [];
+
+  const listener = client.listen(`*[_type == "${listenDocType}"]`);
+  const subscription = listener.subscribe(event => {
+    console.log('Listener received:', event); // For debugging test if it fails
+    receivedEvents.push(event);
+  });
+
+  // Create
+  await client.create({ _id: listenDocId, _type: listenDocType, title: 'Hello' } as SanityDocument);
+  await delay(50); // Allow event propagation
+  assert(receivedEvents.length === 1, 'Client Listen: Expected 1 event after create.');
+  assert(receivedEvents[0].type === 'create' && receivedEvents[0].documentId === listenDocId, 'Client Listen: Create event data incorrect.');
+
+  // Patch (via transaction for LocalSanityClientImpl)
+  await client.patch(listenDocId, { title: 'Updated' }).commit();
+  await delay(50);
+  assert(receivedEvents.length === 2, 'Client Listen: Expected 2 events after patch.');
+  assert(receivedEvents[1].type === 'update' && receivedEvents[1].documentId === listenDocId, 'Client Listen: Patch event data incorrect.');
+  assert(receivedEvents[1].document.title === 'Updated', 'Client Listen: Patch event document data incorrect.');
+
+  // Delete
+  await client.delete(listenDocId);
+  await delay(50);
+  assert(receivedEvents.length === 3, 'Client Listen: Expected 3 events after delete.');
+  assert(receivedEvents[2].type === 'delete' && receivedEvents[2].documentId === listenDocId, 'Client Listen: Delete event data incorrect.');
+
+  // Unsubscribe
+  subscription.unsubscribe();
+  receivedEvents.length = 0; // Clear previous events
+
+  // Perform another operation
+  await client.create({ _id: 'lt2', _type: listenDocType, title: 'After Unsubscribe' } as SanityDocument);
+  await delay(50);
+  assert(receivedEvents.length === 0, 'Client Listen: Listener should not be invoked after unsubscribe.');
+
+  await store.clear(); // clean up lt2
+}
+
+async function testClientAssetUpload() {
+  const client = new LocalSanityClientImpl({ ...defaultClientConfig, assetsDirectory: assetsTestDir, logLevel: 'error' });
+  const store = await getClientStore(client);
+  await store.clear();
+  cleanupAssetsTestDir(); // Ensure clean asset directory
+
+  const dummyAssetPath = path.join(process.cwd(), 'test_asset_upload.txt');
+  fs.writeFileSync(dummyAssetPath, 'Test asset content.');
+
+  const receivedEvents: any[] = [];
+  const listener = client.listen('*[_type == "sanity.fileAsset"]'); // Listen for asset document creation
+  const subscription = listener.subscribe(event => receivedEvents.push(event));
+
+  let assetMeta: AssetMetadata | null = null;
+  try {
+    assetMeta = await client.assets.upload(
+      'file',
+      { path: dummyAssetPath, name: 'test_asset_upload.txt', type: 'text/plain' }
+    );
+
+    assert(assetMeta !== null, 'Client Asset Upload: Metadata should be returned.');
+    assert(assetMeta._type === 'sanity.fileAsset', 'Client Asset Upload: Metadata _type incorrect.');
+    assert(assetMeta.originalFilename === 'test_asset_upload.txt', 'Client Asset Upload: Metadata originalFilename incorrect.');
+    assert(assetMeta.mimeType === 'text/plain', 'Client Asset Upload: Metadata mimeType incorrect.');
+    assert(typeof assetMeta.size === 'number' && assetMeta.size > 0, 'Client Asset Upload: Metadata size incorrect.');
+    assert(assetMeta.url.startsWith('local_assets_test_client/'), 'Client Asset Upload: Metadata URL incorrect.');
+
+    const assetDocInStore = await store.get(assetMeta._id);
+    assert(assetDocInStore !== undefined, 'Client Asset Upload: Asset document should be in store.');
+    assert(assetDocInStore!._id === assetMeta._id, 'Client Asset Upload: Stored asset doc ID mismatch.');
+
+    const expectedLocalPath = path.join(assetsTestDir, path.basename(assetMeta.url));
+    assert(fs.existsSync(expectedLocalPath), `Client Asset Upload: File should exist at ${expectedLocalPath}.`);
+
+    await delay(50); // Allow event for asset doc creation to propagate
+    assert(receivedEvents.length === 1, 'Client Asset Upload: Expected 1 event for asset document creation.');
+    assert(receivedEvents[0].type === 'create' && receivedEvents[0].documentId === assetMeta._id, 'Client Asset Upload: Asset create event data incorrect.');
+
+  } finally {
+    subscription.unsubscribe();
+    if (fs.existsSync(dummyAssetPath)) {
+      fs.unlinkSync(dummyAssetPath);
+    }
+    cleanupAssetsTestDir(); // Clean up asset directory after test
+  }
+}
+
+// --- Test Runner ---
+const tests: { name: string, fn: () => Promise<void> }[] = [
+  { name: 'InMemoryStore: Document Lifecycle', fn: testStoreDocumentLifecycle },
+  { name: 'InMemoryStore: Duplicate ID', fn: testStoreDuplicateId },
+  { name: 'InMemoryStore: Update Non-Existent', fn: testStoreUpdateNonExistent },
+  { name: 'InMemoryStore: Query', fn: testStoreQuery },
+  { name: 'InMemoryStore: Clear', fn: testStoreClear },
+  { name: 'LocalSanityClientImpl: Fetch Queries', fn: testClientFetchQueries },
+  { name: 'LocalSanityClientImpl: Transactions & Events', fn: testClientTransactions },
+  { name: 'LocalSanityClientImpl: Listen', fn: testClientListen },
+  { name: 'LocalSanityClientImpl: Asset Upload & Events', fn: testClientAssetUpload },
+];
+
+async function runTests() {
+  console.log('--- Running Unit Tests ---');
+
+  for (const test of tests) {
+    try {
+      await test.fn();
+      testsPassed++;
+      testResults.push({ name: test.name, passed: true });
+      console.log(`✅ PASSED: ${test.name}`);
+    } catch (e) {
+      testsFailed++;
+      const errorMsg = (e instanceof Error) ? e.message : String(e);
+      testResults.push({ name: test.name, passed: false, error: errorMsg });
+      console.error(`❌ FAILED: ${test.name}`);
+      console.error(`   Error: ${errorMsg}`);
+      if ((e as Error).stack) {
+        console.error(`   Stack: ${(e as Error).stack!.split('\n').slice(1).join('\n')}`);
+      }
+    }
+  }
+
+  console.log('\n--- Test Summary ---');
+  console.log(`${testsPassed} out of ${tests.length} tests passed.`);
+  if (testsFailed > 0) {
+    console.log(`${testsFailed} tests failed.`);
+    testResults.filter(r => !r.passed).forEach(r => {
+        console.log(`  - ${r.name}: ${r.error}`);
+    });
+    process.exitCode = 1; // Indicate failure to CI or other runners
+  } else {
+    console.log('All tests passed successfully!');
+  }
+}
+
+// Execute tests
+runTests().catch(e => {
+  console.error("Critical error during test execution:", e);
+  process.exitCode = 1;
+});

--- a/examples/test-local-project/src/localSanityClient.ts
+++ b/examples/test-local-project/src/localSanityClient.ts
@@ -1,0 +1,597 @@
+import {
+  LocalSanityClientConfig,
+  SanityDocument,
+  LocalSanityClient,
+  Transaction,
+  Mutation,
+  CreateMutation, // Ensure this is imported if used explicitly
+  PatchMutation,  // Ensure this is imported if used explicitly
+  DeleteMutation, // Ensure this is imported if used explicitly
+  SimpleObservable,
+  AssetMetadata,
+  UploadOptions,
+  // SanityDocument, // Removed duplicate import, already imported above
+} from './localSanityTypes';
+import { InMemoryStore } from './inMemoryStore';
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomBytes } from 'crypto';
+
+/**
+ * @internal
+ * A simple event emitter class for handling real-time updates.
+ */
+export class EventEmitter {
+  private listeners: Map<string, Array<(data: any) => void>> = new Map();
+
+  /**
+   * Registers a listener for a specific event.
+   * @param eventName - The name of the event to listen to.
+   * @param callback - The function to call when the event is emitted.
+   */
+  on(eventName: string, callback: (data: any) => void): void {
+    if (!this.listeners.has(eventName)) {
+      this.listeners.set(eventName, []);
+    }
+    this.listeners.get(eventName)!.push(callback);
+  }
+
+  /**
+   * Unregisters a listener for a specific event.
+   * @param eventName - The name of the event.
+   * @param callback - The callback function to remove.
+   */
+  off(eventName: string, callback: (data: any) => void): void {
+    const eventListeners = this.listeners.get(eventName);
+    if (eventListeners) {
+      this.listeners.set(
+        eventName,
+        eventListeners.filter((cb) => cb !== callback)
+      );
+    }
+  }
+
+  /**
+   * Emits an event to all registered listeners for that event.
+   * @param eventName - The name of the event to emit.
+   * @param data - The data to pass to the listeners.
+   */
+  emit(eventName: string, data: any): void {
+    const eventListeners = this.listeners.get(eventName);
+    if (eventListeners) {
+      eventListeners.forEach((callback) => {
+        try {
+          callback(data);
+        } catch (error) {
+          console.error('Error in event listener:', error);
+        }
+      });
+    }
+  }
+}
+
+
+/**
+ * @internal
+ * Implementation of the Transaction interface for the local Sanity client.
+ */
+export class TransactionImpl implements Transaction {
+  private mutations: Mutation[] = [];
+  // private store: InMemoryStore; // store is now passed via constructor property
+
+  /**
+   * Creates an instance of TransactionImpl.
+   * @param store - The InMemoryStore instance to operate on.
+   * @param clientEventEmitter - The EventEmitter instance from the client for emitting mutation events.
+   * @param initialMutations - Optional array of initial mutations.
+   */
+  constructor(
+    private store: InMemoryStore,
+    private clientEventEmitter: EventEmitter,
+    initialMutations: Mutation[] = []
+  ) {
+    if (initialMutations) {
+      this.mutations.push(...initialMutations);
+    }
+  }
+
+  /**
+   * Adds a create operation to the transaction.
+   * @param document - The document to create.
+   * @returns The transaction instance for chaining.
+   */
+  create(document: SanityDocument): Transaction {
+    // Ensure _createdAt and _updatedAt are set if not provided
+    const now = new Date().toISOString();
+    const docToCreate = {
+      ...document,
+      _createdAt: document._createdAt || now,
+      _updatedAt: document._updatedAt || now,
+    };
+    this.mutations.push({ create: { document: docToCreate } });
+    return this;
+  }
+
+  /**
+   * Adds a patch operation to the transaction.
+   * @param id - The ID of the document to patch.
+   * @param fields - The fields to update.
+   *   Note: `_id`, `_type`, `_createdAt` should not be in fields.
+   *   `_updatedAt` will be set by the store during the operation.
+   * @returns The transaction instance for chaining.
+   */
+  patch(id: string, fields: Partial<SanityDocument>): Transaction {
+    // Ensure restricted fields are not in the patch
+    const { _id, _type, _createdAt, _updatedAt, ...patchableFields } = fields;
+    if (Object.keys(patchableFields).length === 0) {
+        console.warn(`Patch for document ID "${id}" is empty or only contains restricted fields. No operation will be performed for this patch.`);
+        return this; // Or throw an error if empty patches are not allowed
+    }
+    this.mutations.push({ patch: { id, fields: patchableFields } });
+    return this;
+  }
+
+  /**
+   * Adds a delete operation to the transaction.
+   * @param id - The ID of the document to delete.
+   * @returns The transaction instance for chaining.
+   */
+  delete(id: string): Transaction {
+    this.mutations.push({ delete: { id } });
+    return this;
+  }
+
+  /**
+   * Commits all mutations in the transaction.
+   * Executes mutations sequentially and stops on the first error.
+   * @returns A promise that resolves with an array of results from each mutation.
+   */
+  async commit(): Promise<{ results: any[] }> {
+    const results: any[] = [];
+    try {
+      for (const mutation of this.mutations) {
+        if ('create' in mutation) {
+          const createdDoc = await this.store.create(mutation.create.document);
+          const result = {
+            id: createdDoc._id,
+            operation: 'create',
+            document: createdDoc,
+          };
+          results.push(result);
+          this.clientEventEmitter.emit('mutation', {
+            type: 'create',
+            documentId: createdDoc._id,
+            document: createdDoc,
+          });
+        } else if ('patch' in mutation) {
+          const patchedDoc = await this.store.update(mutation.patch.id, mutation.patch.fields);
+          const result = {
+            id: patchedDoc._id,
+            operation: 'patch',
+            document: patchedDoc,
+          };
+          results.push(result);
+          this.clientEventEmitter.emit('mutation', {
+            type: 'update', // Sanity uses 'update' or 'mutation' more generally for patches
+            documentId: patchedDoc._id,
+            document: patchedDoc,
+          });
+        } else if ('delete' in mutation) {
+          const deletedDoc = await this.store.delete(mutation.delete.id);
+          const result = {
+            id: mutation.delete.id,
+            operation: 'delete',
+            documentId: deletedDoc?._id,
+          };
+          results.push(result);
+          // For delete, the document itself is gone. We only have the ID.
+          this.clientEventEmitter.emit('mutation', {
+            type: 'delete',
+            documentId: mutation.delete.id,
+          });
+        }
+      }
+      this.mutations = []; // Clear mutations after successful commit
+      return { results };
+    } catch (error) {
+      console.error('Transaction commit failed:', error);
+      throw error;
+    }
+  }
+}
+
+/**
+ * Default configuration for the LocalSanityClient.
+ */
+const DEFAULT_CONFIG: Required<LocalSanityClientConfig> = {
+  localDataPath: '', // Empty means in-memory only by default
+  dataset: 'local',
+  logLevel: 'info',
+};
+
+/**
+ * Implementation of the LocalSanityClient interface.
+ */
+export class LocalSanityClientImpl implements LocalSanityClient {
+  private store: InMemoryStore;
+  public readonly config: Readonly<Required<LocalSanityClientConfig>>;
+  private eventEmitter: EventEmitter = new EventEmitter();
+  private assetsDirectory: string;
+
+  /**
+   * Asset handling methods.
+   */
+  public assets: {
+    upload(
+      assetType: 'file' | 'image',
+      body: File | Blob | Buffer | { path: string; name: string; type: string },
+      opts?: UploadOptions
+    ): Promise<AssetMetadata>;
+  };
+
+  /**
+   * Creates an instance of LocalSanityClientImpl.
+   * @param config - Configuration for the client.
+   */
+  constructor(config?: LocalSanityClientConfig) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.store = new InMemoryStore();
+    // Define assets directory relative to current working directory or a specific app path
+    // For a worker environment, process.cwd() or a pre-defined /app path is typical
+    this.assetsDirectory = path.join(process.cwd(), 'local_assets'); 
+
+    // Initialize asset operations
+    this.assets = {
+      upload: async (
+        assetType: 'file' | 'image',
+        body: File | Blob | Buffer | { path: string; name: string; type: string },
+        opts: UploadOptions = {}
+      ): Promise<AssetMetadata> => {
+        if (this.config.logLevel === 'debug') {
+          console.debug('Asset upload called with:', { assetType, body, opts });
+        }
+
+        // 1. Generate Asset ID
+        const assetId = `${assetType}-${Date.now()}-${randomBytes(8).toString('hex')}`;
+
+        // 2. Determine Metadata
+        let originalFilename: string;
+        let mimeType: string;
+        let size: number;
+        let fileExtension: string;
+
+        if (typeof (body as any).path === 'string') { // Check if body is { path, name, type }
+          const bodyWithPath = body as { path: string; name: string; type: string };
+          originalFilename = opts.filename || bodyWithPath.name;
+          mimeType = opts.contentType || bodyWithPath.type;
+          fileExtension = path.extname(originalFilename) || path.extname(bodyWithPath.path) || '';
+          try {
+            size = fs.statSync(bodyWithPath.path).size;
+          } catch (error) {
+            console.error(`Error getting file size for ${bodyWithPath.path}:`, error);
+            throw new Error(`Failed to get file size for ${bodyWithPath.path}: ${(error as Error).message}`);
+          }
+        } else if (body instanceof Buffer) {
+          originalFilename = opts.filename || `buffer-upload-${Date.now()}`;
+          mimeType = opts.contentType || 'application/octet-stream'; // Default for buffer
+          fileExtension = path.extname(originalFilename) || '';
+          size = body.length;
+        } else if (typeof File !== 'undefined' && body instanceof File) {
+          originalFilename = opts.filename || body.name;
+          mimeType = opts.contentType || body.type;
+          fileExtension = path.extname(originalFilename) || '';
+          size = body.size;
+        } else if (typeof Blob !== 'undefined' && body instanceof Blob) {
+          originalFilename = opts.filename || `blob-upload-${Date.now()}`;
+          mimeType = opts.contentType || body.type || 'application/octet-stream';
+          fileExtension = path.extname(originalFilename) || '';
+          size = body.size;
+        } else {
+          throw new Error('Unsupported body type for asset upload.');
+        }
+        
+        if (!originalFilename) {
+            throw new Error('Filename could not be determined for asset.');
+        }
+
+
+        // 3. Simulate File Storage
+        try {
+          if (!fs.existsSync(this.assetsDirectory)) {
+            fs.mkdirSync(this.assetsDirectory, { recursive: true });
+            if (this.config.logLevel === 'info') {
+              console.info(`Created assets directory: ${this.assetsDirectory}`);
+            }
+          }
+        } catch (error) {
+          console.error(`Error creating assets directory ${this.assetsDirectory}:`, error);
+          throw new Error(`Failed to create assets directory: ${(error as Error).message}`);
+        }
+        
+        const localFilename = `${assetId}${fileExtension}`;
+        const localFilePath = path.join(this.assetsDirectory, localFilename);
+        const assetUrl = `local_assets/${localFilename}`; // URL relative to project root
+
+        try {
+          if (typeof (body as any).path === 'string') {
+            fs.copyFileSync((body as { path: string }).path, localFilePath);
+          } else if (body instanceof Buffer) {
+            fs.writeFileSync(localFilePath, body);
+          } else if (typeof File !== 'undefined' && body instanceof File) {
+            // Simulating File to Buffer conversion for Node.js environment
+            const buffer = Buffer.from(await body.arrayBuffer());
+            fs.writeFileSync(localFilePath, buffer);
+          } else if (typeof Blob !== 'undefined' && body instanceof Blob) {
+            // Simulating Blob to Buffer conversion for Node.js environment
+            const buffer = Buffer.from(await body.arrayBuffer());
+            fs.writeFileSync(localFilePath, buffer);
+          }
+          if (this.config.logLevel === 'info') {
+            console.info(`Asset saved to: ${localFilePath}`);
+          }
+        } catch (error) {
+          console.error(`Error saving asset to ${localFilePath}:`, error);
+          throw new Error(`Failed to save asset: ${(error as Error).message}`);
+        }
+
+        // 4. Create Asset Document
+        const assetDocument: AssetMetadata & SanityDocument = {
+          _id: assetId,
+          _type: assetType === 'image' ? 'sanity.imageAsset' : 'sanity.fileAsset',
+          _createdAt: new Date().toISOString(),
+          _updatedAt: new Date().toISOString(),
+          originalFilename,
+          size,
+          mimeType,
+          url: assetUrl,
+          // Potentially add extension, dimensions (for images) if needed later
+        };
+
+        // 5. Store Asset Document
+        try {
+          // this.store.create will also trigger eventEmitter due to previous work
+          const storedAssetDoc = await this.store.create(assetDocument);
+          if (this.config.logLevel === 'info') {
+            console.info(`Asset metadata document created for ID: ${storedAssetDoc._id}`);
+          }
+          // The storedAssetDoc is already AssetMetadata compatible, but we return the original for clarity
+          return assetDocument as AssetMetadata; 
+        } catch (error) {
+          console.error(`Error storing asset metadata document for ID ${assetId}:`, error);
+          // Attempt to clean up the saved file if metadata storage fails
+          try {
+            fs.unlinkSync(localFilePath);
+            console.warn(`Cleaned up asset file: ${localFilePath}`);
+          } catch (cleanupError) {
+            console.error(`Error cleaning up asset file ${localFilePath}:`, cleanupError);
+          }
+          throw new Error(`Failed to store asset metadata: ${(error as Error).message}`);
+        }
+      },
+    };
+
+    if (this.config.logLevel === 'debug') {
+      console.debug('LocalSanityClient initialized with config:', this.config);
+    }
+  }
+
+  /**
+   * Fetches data based on a simplified query.
+   * @param query - The query string (e.g., documentId, *[_type == "typeName"], *).
+   * @param params - Optional parameters for the query (used with _type queries).
+   * @returns A promise that resolves with the query result.
+   */
+  async fetch(query: string, params?: Record<string, any>): Promise<any> {
+    if (this.config.logLevel === 'debug') {
+      console.debug(`Fetching query: "${query}" with params:`, params);
+    }
+
+    // Check if query is a simple ID (no spaces, not a wildcard)
+    if (!query.includes(' ') && !query.includes('[') && query !== '*') {
+      return this.store.get(query);
+    }
+
+    // Check for *[_type == "typeName"]
+    const typeQueryMatch = query.match(/^\*\[_type == ["']([^"']+)["']\]$/);
+    if (typeQueryMatch) {
+      const typeName = typeQueryMatch[1];
+      return this.store.query(doc => doc._type === typeName);
+    }
+    
+    // Check for *[_type == $typeNameParam]
+    const typeParamQueryMatch = query.match(/^\*\[_type == \$([a-zA-Z_][a-zA-Z0-9_]*)\]$/);
+    if (typeParamQueryMatch && params) {
+        const paramName = typeParamQueryMatch[1];
+        if (params[paramName]) {
+            const typeName = params[paramName];
+            return this.store.query(doc => doc._type === typeName);
+        } else {
+            console.warn(`Parameter "${paramName}" not provided for query: ${query}`);
+            return [];
+        }
+    }
+
+
+    // Check for * (select all)
+    if (query === '*') {
+      return this.store.query(() => true);
+    }
+
+    console.warn(`Query not recognized or not implemented: "${query}"`);
+    return []; // Return empty array for unrecognized queries
+  }
+
+  /**
+   * Retrieves a single document by its ID.
+   * @param id - The ID of the document to retrieve.
+   * @returns A promise that resolves with the document, or undefined if not found.
+   */
+  async getDocument(id: string): Promise<SanityDocument | undefined> {
+    if (this.config.logLevel === 'debug') {
+      console.debug(`Getting document with ID: "${id}"`);
+    }
+    return this.store.get(id);
+  }
+
+  /**
+   * Creates a new document.
+   * Sets `_createdAt` and `_updatedAt` timestamps.
+   * @param document - The document to create.
+   * @returns A promise that resolves with the created document.
+   */
+  async create(document: SanityDocument): Promise<SanityDocument> {
+    const now = new Date().toISOString();
+    const docToCreate: SanityDocument = {
+      ...document,
+      _createdAt: document._createdAt || now,
+      _updatedAt: document._updatedAt || now,
+    };
+    if (this.config.logLevel === 'debug') {
+      console.debug('Creating document:', docToCreate);
+    }
+    const createdDoc = await this.store.create(docToCreate);
+    this.eventEmitter.emit('mutation', {
+      type: 'create',
+      documentId: createdDoc._id,
+      document: createdDoc,
+    });
+    return createdDoc;
+  }
+
+  /**
+   * Creates a transaction with a patch operation.
+   * The transaction's commit will handle updating `_updatedAt`.
+   * @param id - The ID of the document to patch.
+   * @param fields - The fields to update. Restricted fields like `_id`, `_type`, `_createdAt` are ignored.
+   * @returns A transaction instance for chaining.
+   */
+  patch(id: string, fields: Partial<SanityDocument>): Transaction {
+    if (this.config.logLevel === 'debug') {
+      console.debug(`Patching document ID "${id}" with fields:`, fields);
+    }
+    // Pass the eventEmitter to the TransactionImpl
+    return new TransactionImpl(this.store, this.eventEmitter).patch(id, fields);
+  }
+
+  /**
+   * Deletes a document by its ID directly (bypassing transaction).
+   * @param id - The ID of the document to delete.
+   * @returns A promise that resolves with an object containing the ID of the deleted document.
+   */
+  async delete(id: string): Promise<{ results: { id: string }[] }> {
+    if (this.config.logLevel === 'debug') {
+      console.debug(`Deleting document with ID: "${id}"`);
+    }
+    const deletedDoc = await this.store.delete(id);
+    if (deletedDoc) {
+      this.eventEmitter.emit('mutation', {
+        type: 'delete',
+        documentId: id,
+      });
+    }
+    return { results: [{ id: deletedDoc ? deletedDoc._id : id }] };
+  }
+
+  /**
+   * Starts a new transaction.
+   * @returns A new transaction instance.
+   */
+  transaction(): Transaction {
+    if (this.config.logLevel === 'debug') {
+      console.debug('Starting new transaction');
+    }
+    // Pass the eventEmitter to the TransactionImpl
+    return new TransactionImpl(this.store, this.eventEmitter);
+  }
+
+  /**
+   * Listens for real-time updates based on a query.
+   * @param query - The query string (e.g., documentId, *[_type == "typeName"], *).
+   * @param params - Optional parameters for the query (used with _type queries).
+   * @returns A SimpleObservable to subscribe to updates.
+   */
+  listen(query: string, params?: Record<string, any>): SimpleObservable {
+    if (this.config.logLevel === 'debug') {
+      console.debug(`Listening to query: "${query}" with params:`, params);
+    }
+
+    const eventEmitter = this.eventEmitter;
+
+    return {
+      subscribe: (
+        observer: (event: any) => void
+      ): { unsubscribe(): void } => {
+        const listenerCallback = (eventData: any) => {
+          if (this.config.logLevel === 'debug') {
+            console.debug('Listener received event:', eventData, 'for query:', query);
+          }
+
+          // Document ID query
+          if (!query.includes('[') && query !== '*') {
+            if (eventData.documentId === query) {
+              observer(eventData);
+            }
+            return;
+          }
+
+          // *[_type == "typeName"] query
+          const typeQueryMatch = query.match(/^\*\[_type == ["']([^"']+)["']\]$/);
+          if (typeQueryMatch) {
+            const typeName = typeQueryMatch[1];
+            if (eventData.type === 'delete') {
+              // For deletes, we don't have the full document to check _type.
+              // A more advanced system might look up the document before deletion
+              // or require the delete event to carry more info.
+              // For now, we can pass delete events if the query is for a type,
+              // and the consumer can decide. Or filter them out.
+              // Let's pass it and let consumer decide.
+              observer(eventData);
+            } else if (eventData.document && eventData.document._type === typeName) {
+              observer(eventData);
+            }
+            return;
+          }
+          
+          // *[_type == $typeNameParam] query
+          const typeParamQueryMatch = query.match(/^\*\[_type == \$([a-zA-Z_][a-zA-Z0-9_]*)\]$/);
+          if (typeParamQueryMatch && params) {
+            const paramName = typeParamQueryMatch[1];
+            if (params[paramName]) {
+                const typeName = params[paramName];
+                 if (eventData.type === 'delete') {
+                    observer(eventData); // Same reasoning as above for deletes
+                 } else if (eventData.document && eventData.document._type === typeName) {
+                    observer(eventData);
+                 }
+            } else {
+                if (this.config.logLevel === 'warn') {
+                    console.warn(`Parameter "${paramName}" not provided for listen query: ${query}`);
+                }
+            }
+            return;
+          }
+
+
+          // Wildcard query '*'
+          if (query === '*') {
+            observer(eventData);
+            return;
+          }
+          // If no specific query matched, and it's not wildcard, do nothing.
+          // Or, if desired, log a warning for unrecognized listen queries.
+        };
+
+        eventEmitter.on('mutation', listenerCallback);
+
+        return {
+          unsubscribe: () => {
+            if (this.config.logLevel === 'debug') {
+              console.debug('Unsubscribing listener for query:', query);
+            }
+            eventEmitter.off('mutation', listenerCallback);
+          },
+        };
+      },
+    };
+  }
+}

--- a/examples/test-local-project/src/localSanityTypes.ts
+++ b/examples/test-local-project/src/localSanityTypes.ts
@@ -1,0 +1,265 @@
+/**
+ * @remarks
+ * This file contains type definitions for a local Sanity client implementation.
+ */
+
+/**
+ * Configuration for the local Sanity client.
+ */
+export interface LocalSanityClientConfig {
+  /**
+   * Optional path to a local directory for data persistence.
+   * If not provided, data will be in-memory.
+   */
+  localDataPath?: string;
+
+  /**
+   * Optional dataset name, similar to Sanity's dataset concept.
+   * Defaults to 'local'.
+   */
+  dataset?: string;
+
+  /**
+   * Optional logging level for the client.
+   * Defaults to 'info'.
+   */
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+}
+
+/**
+ * Represents a generic Sanity document.
+ */
+export interface SanityDocument {
+  /**
+   * Unique identifier for the document.
+   */
+  _id: string;
+
+  /**
+   * Type of the document (e.g., 'product', 'user').
+   */
+  _type: string;
+
+  /**
+   * ISO 8601 timestamp of when the document was created.
+   */
+  _createdAt: string;
+
+  /**
+   * ISO 8601 timestamp of when the document was last updated.
+   */
+  _updatedAt: string;
+
+  /**
+   * Allows for any other properties on the document.
+   */
+  [key: string]: any;
+}
+
+/**
+ * Represents a create mutation operation.
+ */
+export interface CreateMutation {
+  create: { document: SanityDocument };
+}
+
+/**
+ * Represents a patch mutation operation.
+ */
+export interface PatchMutation {
+  patch: { id: string; fields: Partial<SanityDocument> };
+}
+
+/**
+ * Represents a delete mutation operation.
+ */
+export interface DeleteMutation {
+  delete: { id: string };
+}
+
+/**
+ * Represents a single mutation operation.
+ * This can be a create, patch, or delete operation.
+ */
+export type Mutation = CreateMutation | PatchMutation | DeleteMutation;
+
+/**
+ * Interface for transaction objects, which can apply multiple mutations.
+ */
+export interface Transaction {
+  /**
+   * Adds a create operation to the transaction.
+   * @param document - The document to create.
+   * @returns The transaction instance for chaining.
+   */
+  create(document: SanityDocument): Transaction;
+
+  /**
+   * Adds a patch operation to the transaction.
+   * @param id - The ID of the document to patch.
+   * @param fields - The fields to update.
+   * @returns The transaction instance for chaining.
+   */
+  patch(id: string, fields: Partial<SanityDocument>): Transaction;
+
+  /**
+   * Adds a delete operation to the transaction.
+   * @param id - The ID of the document to delete.
+   * @returns The transaction instance for chaining.
+   */
+  delete(id: string): Transaction;
+
+  /**
+   * Commits all mutations in the transaction.
+   * @returns A promise that resolves when the transaction is complete,
+   *          optionally with results similar to Sanity.
+   */
+  commit(): Promise<{results: any[]}>; // Or Promise<void> if results are not needed
+}
+
+/**
+ * Represents metadata for an uploaded asset.
+ */
+export interface AssetMetadata {
+  /**
+   * Unique identifier for the asset.
+   */
+  _id: string;
+
+  /**
+   * Type of the asset.
+   * 'sanity.fileAsset' and 'sanity.imageAsset' are standard Sanity types.
+   * Custom local types can also be used.
+   */
+  _type: 'sanity.fileAsset' | 'sanity.imageAsset' | string;
+
+  /**
+   * The original filename of the uploaded asset.
+   */
+  originalFilename: string;
+
+  /**
+   * Size of the asset in bytes.
+   */
+  size: number;
+
+  /**
+   * MIME type of the asset (e.g., 'image/jpeg', 'application/pdf').
+   */
+  mimeType: string;
+
+  /**
+   * URL or local path to access the asset.
+   */
+  url: string;
+}
+
+/**
+ * Optional parameters for asset uploads.
+ */
+export interface UploadOptions {
+  /**
+   * Optional desired filename for the asset.
+   */
+  filename?: string;
+
+  /**
+   * Optional content type (MIME type) of the asset.
+   */
+  contentType?: string;
+}
+
+/**
+ * A simplified Observable-like interface for real-time updates.
+ */
+export interface SimpleObservable {
+  /**
+   * Subscribes to events from the observable.
+   * @param observer - A function that will be called with new events.
+   * @returns An object with an `unsubscribe` method to stop listening.
+   */
+  subscribe(observer: (event: any) => void): { unsubscribe(): void };
+}
+
+/**
+ * The main interface for the local Sanity client.
+ */
+export interface LocalSanityClient {
+  /**
+   * Readonly configuration object for the client.
+   */
+  readonly config: Readonly<LocalSanityClientConfig>;
+
+  /**
+   * Asset handling methods.
+   */
+  assets: {
+    /**
+     * Uploads an asset (file or image).
+     * @param assetType - The type of asset to upload ('file' or 'image').
+     * @param body - The asset data (File, Blob, or Buffer).
+     * @param opts - Optional parameters for the upload.
+     * @returns A promise that resolves with the metadata of the uploaded asset.
+     */
+    upload(
+      assetType: 'file' | 'image',
+      body: File | Blob | Buffer | { path: string; name: string; type: string },
+      opts?: UploadOptions
+    ): Promise<AssetMetadata>;
+  };
+
+  /**
+   * Fetches data based on a query.
+   * Note: Query syntax will be simplified and not full GROQ.
+   * @param query - The query string.
+   * @param params - Optional parameters for the query.
+   * @returns A promise that resolves with the query result.
+   */
+  fetch(query: string, params?: Record<string, any>): Promise<any>;
+
+  /**
+   * Retrieves a single document by its ID.
+   * @param id - The ID of the document to retrieve.
+   * @returns A promise that resolves with the document, or undefined if not found.
+   */
+  getDocument(id: string): Promise<SanityDocument | undefined>;
+
+  /**
+   * Creates a new document.
+   * @param document - The document to create.
+   * @returns A promise that resolves with the created document.
+   */
+  create(document: SanityDocument): Promise<SanityDocument>;
+
+  /**
+   * Patches an existing document.
+   * This can return a transaction for chaining or apply the patch directly.
+   * @param id - The ID of the document to patch.
+   * @param fields - The fields to update.
+   * @returns A transaction instance for chaining, or a promise if applied directly.
+   */
+  patch(id: string, fields: Partial<SanityDocument>): Transaction; // Or Promise<SanityDocument>
+
+  /**
+   * Deletes a document by its ID.
+   * @param id - The ID of the document to delete.
+   * @returns A promise that resolves when the deletion is complete,
+   *          optionally with results.
+   */
+  delete(id: string): Promise<{ results: {id: string}[] }>; // Or Promise<void>
+
+  /**
+   * Starts a new transaction.
+   * @returns A new transaction instance.
+   */
+  transaction(): Transaction;
+
+  /**
+   * Listens for real-time updates based on a query.
+   * Uses a simplified Observable-like interface.
+   * @param query - The query string to listen for.
+   * @param params - Optional parameters for the query.
+   * @returns A SimpleObservable to subscribe to updates.
+   */
+  listen(query: string, params?: Record<string, any>): SimpleObservable;
+}

--- a/examples/test-local-project/tsconfig.json
+++ b/examples/test-local-project/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
This commit introduces a new example project located at `examples/test-local-project/`. This project demonstrates the integration and usage of the previously developed local Sanity client replacement.

The example project includes:
- Its own `package.json` with scripts and dependencies (`typescript`, `ts-node`).
- A `tsconfig.json` for TypeScript compilation.
- A `src/` directory containing all the local Sanity client implementation files:
    - `localSanityTypes.ts`
    - `inMemoryStore.ts`
    - `localSanityClient.ts`
    - `example.sanity.config.ts`
    - `example.usage.ts` (updated for the new project structure)
    - `localApi.test.ts`
- A `README.md` file with instructions on how to set up, run the example usage script, and execute tests.

This project serves as a self-contained environment to test and showcase the capabilities of the local Sanity API alternative.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
